### PR TITLE
Fix EditorConfig syntax error

### DIFF
--- a/{{cookiecutter.project_slug}}/.editorconfig
+++ b/{{cookiecutter.project_slug}}/.editorconfig
@@ -30,7 +30,7 @@ indent_size = 2
 [*.{markdown,md}]
 trim_trailing_whitespace = false
 
-*.xml]
+[*.xml]
 indent_size = 2
 insert_final_newline = false
 


### PR DESCRIPTION
In the EditorConfig changes in 55120389198e558797a86f22fa07bbe3811f36a4, there's a syntax error in one of the rules.